### PR TITLE
WPML compatibility

### DIFF
--- a/ajax-archive-calendar.php
+++ b/ajax-archive-calendar.php
@@ -318,20 +318,6 @@ function ajax_ac_calendar($ma, $echo = true) {
 	$unixmonth = mktime(0, 0 , 0, $thismonth, 1, $thisyear);
 	$last_day = date('t', $unixmonth);
 
-	// Get the next and previous month and year with at least one post
-	$previous = $wpdb->get_row("SELECT MONTH(post_date) AS month, YEAR(post_date) AS year
-		FROM $wpdb->posts
-		WHERE post_date < '$thisyear-$thismonth-01'
-		AND post_type = 'post' AND post_status = 'publish'
-			ORDER BY post_date DESC
-			LIMIT 1");
-	$next = $wpdb->get_row("SELECT MONTH(post_date) AS month, YEAR(post_date) AS year
-		FROM $wpdb->posts
-		WHERE post_date > '$thisyear-$thismonth-{$last_day} 23:59:59'
-		AND post_type = 'post' AND post_status = 'publish'
-			ORDER BY post_date ASC
-			LIMIT 1");
-
 	$calendar_output = '<table id="my-calendar">
 	<thead>
 	<tr>';
@@ -357,27 +343,6 @@ function ajax_ac_calendar($ma, $echo = true) {
 	$calendar_output .= '
 	</tr>
 	</thead>
-<!-----
-	<tfoot>
-	<tr>';
-
-	if ( $previous ) {
-		$calendar_output .= "\n\t\t".'<td colspan="3" id="prev"><a href="' . get_month_link($previous->year, $previous->month) . '" title="' . esc_attr( sprintf(__('View posts for %1$s %2$s'), $wp_locale->get_month($previous->month), date('Y', mktime(0, 0 , 0, $previous->month, 1, $previous->year)))) . '">&laquo; ' . $wp_locale->get_month_abbrev($wp_locale->get_month($previous->month)) . '</a></td>';
-	} else {
-		$calendar_output .= "\n\t\t".'<td colspan="3" id="prev" class="pad">&nbsp;</td>';
-	}
-
-	$calendar_output .= "\n\t\t".'<td class="pad">&nbsp;</td>';
-
-	if ( $next ) {
-		$calendar_output .= "\n\t\t".'<td colspan="3" id="next"><a href="' . get_month_link($next->year, $next->month) . '" title="' . esc_attr( sprintf(__('View posts for %1$s %2$s'), $wp_locale->get_month($next->month), date('Y', mktime(0, 0 , 0, $next->month, 1, $next->year))) ) . '">' . $wp_locale->get_month_abbrev($wp_locale->get_month($next->month)) . ' &raquo;</a></td>';
-	} else {
-		$calendar_output .= "\n\t\t".'<td colspan="3" id="next" class="pad">&nbsp;</td>';
-	}
-
-	$calendar_output .= '
-	</tr>
-	</tfoot> -------->
 
 	<tbody>
 	<tr>';

--- a/ajax-archive-calendar.php
+++ b/ajax-archive-calendar.php
@@ -288,6 +288,12 @@ add_action( 'wp_ajax_ajax_ac', 'ajax_ac_callback' );
 add_action( 'wp_ajax_nopriv_ajax_ac', 'ajax_ac_callback' );
 
 function ajax_ac_callback() {
+$ma=$_GET['ma'];
+$bn=$_GET['bn'];
+ajax_ac_calendar($ma,$bn);
+	die(); // this is required to return a proper result
+}
+
 
 function ajax_ac_calendar($ma,$bn,$initial = true, $echo = true) {
 	global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
@@ -568,12 +574,6 @@ $dayrrr=array(
 	else
 		return apply_filters( 'get_calendar',  $calendar_output );
 
-}
-
-$ma=$_GET['ma'];
-$bn=$_GET['bn'];
-ajax_ac_calendar($ma,$bn);
-	die(); // this is required to return a proper result
 }
 
 function ajax_ac_head(){?>

--- a/ajax-archive-calendar.php
+++ b/ajax-archive-calendar.php
@@ -70,10 +70,27 @@ class ajax_ac_widget extends WP_Widget {
 			<div class="select_ca">
 				<select name="month" id="my_month" >
 					<?php
-					$month = array();
-					for ($i = 1; $i <= 12; $i++) {
-						$monthnum = zeroise($i, 2);
-						$month[$monthnum] = $wp_locale->get_month($i);
+					if ('bn' === substr(get_locale(), 0, 2)) {
+						$month=array(
+							'01'=>'জানুয়ারী',
+							'02'=>'ফেব্রুয়ারী',
+							'03'=>'মার্চ',
+							'04'=>'এপ্রিল',
+							'05'=>'মে',
+							'06'=>'জুন',
+							'07'=>'জুলাই',
+							'08'=>'আগষ্ট',
+							'09'=>'সেপ্টেম্বর',
+							'10'=>'অক্টবর',
+							'11'=>'নভেম্বর',
+							'12'=>'ডিসেম্বর'
+						);
+					} else{
+						$month = array();
+						for ($i = 1; $i <= 12; $i++) {
+							$monthnum = zeroise($i, 2);
+							$month[$monthnum] = $wp_locale->get_month($i);
+						}
 					}
 
 					global $m;

--- a/ajax-archive-calendar.php
+++ b/ajax-archive-calendar.php
@@ -49,8 +49,7 @@ class ajax_ac_widget extends WP_Widget {
 		);
 	}
 
-	/**
-	  /********************** It will be sow home page**************** */
+	/********************** It will be sow home page**************** */
 	function widget($args, $instance) {
 		global $wp_locale;
 

--- a/ajax-archive-calendar.php
+++ b/ajax-archive-calendar.php
@@ -332,10 +332,7 @@ function ajax_ac_calendar($ma, $echo = true) {
 			ORDER BY post_date ASC
 			LIMIT 1");
 
-	/* translators: Calendar caption: 1: month name, 2: 4-digit year */
-	$calendar_caption = _x('%1$s %2$s', 'calendar caption');
 	$calendar_output = '<table id="my-calendar">
-	<!-- <caption>' . sprintf($calendar_caption, $wp_locale->get_month($thismonth), date('Y', $unixmonth)) . '</caption> --->
 	<thead>
 	<tr>';
 

--- a/ajax-archive-calendar.php
+++ b/ajax-archive-calendar.php
@@ -9,10 +9,21 @@ Author URI: http://www.projapotibd.com/
 */
 
 /**
+ * Enqueue frontend scripts.
+ */
+add_action('wp_enqueue_scripts', 'ajax_ac_enqueue_scripts');
+
+/**
+ * Make sure we have jquery available.
+ */
+function ajax_ac_enqueue_scripts() {
+	wp_enqueue_script('jquery');
+}
+
+/**
  * Add function to widgets_init that'll load our widget.
  * @since 0.1
  */
-wp_enqueue_script( 'jquery' );
 add_action( 'widgets_init', 'ajax_ac_int' );
 
 /**

--- a/ajax-archive-calendar.php
+++ b/ajax-archive-calendar.php
@@ -299,7 +299,7 @@ function ajax_ac_calendar($ma,$bn,$initial = true, $echo = true) {
 	global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
 	$m=& $ma;
 	$cache = array();
-	$key = md5( $m . $monthnum . $year );
+	$key = md5( get_locale() . $m . $monthnum . $year );
 	
 	if ( $cache = wp_cache_get( 'get_calendar', 'calendar' ) ) {
 		if ( is_array($cache) && isset( $cache[ $key ] ) ) {

--- a/ajax-archive-calendar.php
+++ b/ajax-archive-calendar.php
@@ -259,7 +259,7 @@ ajax_ac_calendar($ma);
 }
 
 
-function ajax_ac_calendar($ma,$initial = true, $echo = true) {
+function ajax_ac_calendar($ma, $echo = true) {
 	global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
 	$m=& $ma;
 	$cache = array();
@@ -345,13 +345,13 @@ function ajax_ac_calendar($ma,$initial = true, $echo = true) {
 		$myweek[] = $wp_locale->get_weekday(($wdcount+$week_begins)%7);
 	}
 
+	$barr=array('Saturday'=>'শনি','Sunday'=>'রবি','Monday'=>'সোম','Tuesday'=>'মঙ্গল','Wednesday'=>'বুধ','Thursday'=>'বৃহ','Friday'=>'শুক্র');
 	foreach ( $myweek as $wd ) {
-$barr=array('Saturday'=>'শনি','Sunday'=>'রবি','Monday'=>'সোম','Tuesday'=>'মঙ্গল','Wednesday'=>'বুধ','Thursday'=>'বৃহ','Friday'=>'শুক্র');
 		if ('bn' === substr(get_locale(), 0, 2)) {
 			$day_name=$barr[$wd];
 			}
 		else{
-		$day_name = (true == $initial) ? $wp_locale->get_weekday_abbrev($wd) : $wp_locale->get_weekday_abbrev($wd);
+		$day_name = $wp_locale->get_weekday_abbrev($wd);
 		}
 		$wd = esc_attr($wd);
 		$calendar_output .= "\n\t\t<th class=\"$day_name\" scope=\"col\" title=\"$wd\">$day_name</th>";

--- a/ajax-archive-calendar.php
+++ b/ajax-archive-calendar.php
@@ -106,8 +106,8 @@ else{
 	
 global $m;
 if(empty($m) || $m==''){
-	$nowm=date(m);
-	$nowyear=date(Y);
+	$nowm=date('m');
+	$nowyear=date('Y');
 	}
 else {
 	$mmm = str_split($m, 2);
@@ -223,7 +223,7 @@ jQuery(document).ready(function(e) {
 
 jQuery(document).ready(function(e) {
 	<?php echo 'var bna='.$bn.';' ?>
-	<?php if(!isset($_GET['m'])){ echo 'var a='.date(Ym);} else echo 'var a='.$_GET['m'];  ?>
+	<?php if(!isset($_GET['m'])){ echo 'var a='.date('Ym');} else echo 'var a='.$_GET['m'];  ?>
 	
  	var data = {
 		action: 'ajax_ac',
@@ -641,7 +641,7 @@ var ajaxurl = '<?php echo admin_url('admin-ajax.php'); ?>';
 </style>
 <?php	
 	}
-	add_filter('wp_head',ajax_ac_head);
+	add_filter('wp_head', 'ajax_ac_head');
 	
 
 ?>

--- a/ajax-archive-calendar.php
+++ b/ajax-archive-calendar.php
@@ -53,11 +53,11 @@ function __construct() {
 /********************** It will be sow home page*****************/
 	
 	function widget( $args, $instance ) {
+		global $wp_locale;
+
 		extract( $args );
 		$title = apply_filters('widget_title', $instance['title'] );
-		
-		$bn = $instance['bangla'];
-		
+				
 		/* Before widget (defined by themes). */
 		echo $before_widget;
 		
@@ -71,38 +71,12 @@ function __construct() {
         <div id="ajax_ac_widget">
      <div class="select_ca">
      <select name="month" id="my_month" >
-
-<?php if($bn=='1'){ $month=array(
-	'01'=>'জানুয়ারী',
-	'02'=>'ফেব্রুয়ারী',
-	'03'=>'মার্চ',
-	'04'=>'এপ্রিল',
-	'05'=>'মে',
-	'06'=>'জুন',
-	'07'=>'জুলাই',
-	'08'=>'আগষ্ট',
-	'09'=>'সেপ্টেম্বর',
-	'10'=>'অক্টবর',
-	'11'=>'নভেম্বর',
-	'12'=>'ডিসেম্বর',
-	);
+<?php
+$month = array();
+for ($i = 1; $i <= 12; $i++) {
+	$monthnum = zeroise($i, 2);
+	$month[$monthnum] = $wp_locale->get_month($i);
 }
-else{
-	$month=array(
-	'01'=>'January',
-	'02'=>'February',
-	'03'=>'March',
-	'04'=>'April',
-	'05'=>'May',
-	'06'=>'Jun',
-	'07'=>'July',
-	'08'=>'August',
-	'09'=>'Septembar',
-	'10'=>'Octobor',
-	'11'=>'Novembar',
-	'12'=>'Decembar',
-	);
-	}
 	
 global $m;
 if(empty($m) || $m==''){
@@ -143,7 +117,7 @@ $replace = array("১","২","৩","৪","৫","৬","৭","৮","৯","০",);
    
       <select name="Year" id="my_year" >
    <?php  foreach($yeararr as $k=>$year){
-	   if($bn=='1'){
+	if ('bn' === substr(get_locale(), 0, 2)) {
 	   $year=str_replace($find,$replace,$year);
 	   }
 	   if($k==$nowyear){
@@ -166,14 +140,12 @@ $replace = array("১","২","৩","৪","৫","৬","৭","৮","৯","০",);
 jQuery('#my_month').change(function(e) {
 	jQuery(".aj-loging").css("display","block");
 	jQuery("#my_calender").css("opacity","0.30");
-	<?php echo 'var bna='.$bn.';' ?>
     var mon=jQuery(this).val();
 	var year=jQuery('#my_year').val();
 	var to=year+mon;
 	var data = {
 		action: 'ajax_ac',
 		ma: to,
-		bn:bna,
 		
 	};
 
@@ -193,14 +165,12 @@ jQuery(document).ready(function(e) {
 jQuery('#my_year').change(function(e) {
 	jQuery(".aj-loging").css("display","block");
 	jQuery("#my_calender").css("opacity","0.30");
-	<?php echo 'var bna='.$bn.';' ?>
     var mon=jQuery('#my_month').val();
 	var year=jQuery('#my_year').val();
 	var to=year+mon;
 	var data = {
 		action: 'ajax_ac',
 		ma: to,
-		bn: bna
 		
 		
 	};
@@ -222,13 +192,11 @@ jQuery(document).ready(function(e) {
 
 
 jQuery(document).ready(function(e) {
-	<?php echo 'var bna='.$bn.';' ?>
 	<?php if(!isset($_GET['m'])){ echo 'var a='.date('Ym');} else echo 'var a='.$_GET['m'];  ?>
 	
  	var data = {
 		action: 'ajax_ac',
 		ma:a,
-		bn:bna,
 		
 	};
 
@@ -261,21 +229,18 @@ jQuery(document).ready(function(e) {
 function update( $new_instance, $old_instance ) {
 		$instance = $old_instance;
 		$instance['title'] = strip_tags( $new_instance['title'] );
-		$instance['bangla'] = strip_tags( $new_instance['bangla'] );
 		return $instance;
 	}
 /************************ It is sow only admin menu**********************************/
 	
 	function form( $instance ) {
-		$defaults = array( 'title' => 'Archive Calendar','bangla'=>'0');
+		$defaults = array( 'title' => 'Archive Calendar');
 		$instance = wp_parse_args( (array) $instance, $defaults );
 		?>
    <p>
 			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e('Title:', 'Recent post'); ?></label>
 			<input id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" value="<?php echo $instance['title']; ?>" style="width:100%;" />
             
-            <label for="<?php echo $this->get_field_id( 'bangla' ); ?>"><?php _e('For Bangla type 1, Default 0 for English:', 'Recent post'); ?></label>
-			<input id="<?php echo $this->get_field_id( 'bangla' ); ?>" name="<?php echo $this->get_field_name( 'bangla' ); ?>" value="<?php echo $instance['bangla']; ?>" style="width:100%;" />
 		</p>
         
          		
@@ -289,13 +254,12 @@ add_action( 'wp_ajax_nopriv_ajax_ac', 'ajax_ac_callback' );
 
 function ajax_ac_callback() {
 $ma=$_GET['ma'];
-$bn=$_GET['bn'];
-ajax_ac_calendar($ma,$bn);
+ajax_ac_calendar($ma);
 	die(); // this is required to return a proper result
 }
 
 
-function ajax_ac_calendar($ma,$bn,$initial = true, $echo = true) {
+function ajax_ac_calendar($ma,$initial = true, $echo = true) {
 	global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
 	$m=& $ma;
 	$cache = array();
@@ -383,7 +347,7 @@ function ajax_ac_calendar($ma,$bn,$initial = true, $echo = true) {
 
 	foreach ( $myweek as $wd ) {
 $barr=array('Saturday'=>'শনি','Sunday'=>'রবি','Monday'=>'সোম','Tuesday'=>'মঙ্গল','Wednesday'=>'বুধ','Thursday'=>'বৃহ','Friday'=>'শুক্র');
-		if($bn=='1'){
+		if ('bn' === substr(get_locale(), 0, 2)) {
 			$day_name=$barr[$wd];
 			}
 		else{
@@ -468,7 +432,7 @@ $barr=array('Saturday'=>'শনি','Sunday'=>'রবি','Monday'=>'সোম',
 
 	$daysinmonth = intval(date('t', $unixmonth));
 	for ( $day = 1; $day <= $daysinmonth; ++$day ) {
-if($bn==1){
+if ('bn' === substr(get_locale(), 0, 2)) {
 $dayrrr=array(
 '1'=>'১',
 '2'=>'২',

--- a/ajax-archive-calendar.php
+++ b/ajax-archive-calendar.php
@@ -1,12 +1,12 @@
 <?php
 /*
-Plugin Name: Ajax Archive Calendar
-Plugin URI: http://projapotibd.com
-Description:Ajax Archive Calendar is not only Calendar is also Archive. It is making by customize WordPress default calendar. I hope every body enjoy this plugin.
-Author: osmansorkar
-Version: 2.5
-Author URI: http://www.projapotibd.com/
-*/
+  Plugin Name: Ajax Archive Calendar
+  Plugin URI: http://projapotibd.com
+  Description:Ajax Archive Calendar is not only Calendar is also Archive. It is making by customize WordPress default calendar. I hope every body enjoy this plugin.
+  Author: osmansorkar
+  Version: 2.5
+  Author URI: http://www.projapotibd.com/
+ */
 
 /**
  * Enqueue frontend scripts.
@@ -24,7 +24,7 @@ function ajax_ac_enqueue_scripts() {
  * Add function to widgets_init that'll load our widget.
  * @since 0.1
  */
-add_action( 'widgets_init', 'ajax_ac_int' );
+add_action('widgets_init', 'ajax_ac_int');
 
 /**
  * Register our widget.
@@ -33,289 +33,290 @@ add_action( 'widgets_init', 'ajax_ac_int' );
  * @since 0.1
  */
 function ajax_ac_int() {
-	register_widget( 'ajax_ac_widget' );
+	register_widget('ajax_ac_widget');
 }
-/***********************************************************/
+
+/* * ******************************************************** */
 
 class ajax_ac_widget extends WP_Widget {
-	
-function __construct() {
-	
+
+	function __construct() {
+
 		parent::__construct(
-	 		'ajax_ac_widget', // Base ID
+			'ajax_ac_widget', // Base ID
 			'Ajax Archive calendar', // Name
-			array( 'description' =>'It is Ajax Archive Calendar', 'text_domain' ) // Args
+			array('description' => 'It is Ajax Archive Calendar', 'text_domain') // Args
 		);
 	}
-	
 
-/**
-/********************** It will be sow home page*****************/
-	
-	function widget( $args, $instance ) {
+	/**
+	  /********************** It will be sow home page**************** */
+	function widget($args, $instance) {
 		global $wp_locale;
 
-		extract( $args );
-		$title = apply_filters('widget_title', $instance['title'] );
-				
+		extract($args);
+		$title = apply_filters('widget_title', $instance['title']);
+
 		/* Before widget (defined by themes). */
 		echo $before_widget;
-		
+
 		/* $title define by from */
-		if ( $title )
+		if ($title)
 		/* after title and before title defince by thime */
-			echo $before_title . $title .$after_title;
-			/* end title */
+			echo $before_title . $title . $after_title;
+		/* end title */
 		/* now start your degine */
 		?>
-        <div id="ajax_ac_widget">
-     <div class="select_ca">
-     <select name="month" id="my_month" >
-<?php
-$month = array();
-for ($i = 1; $i <= 12; $i++) {
-	$monthnum = zeroise($i, 2);
-	$month[$monthnum] = $wp_locale->get_month($i);
-}
-	
-global $m;
-if(empty($m) || $m==''){
-	$nowm=date('m');
-	$nowyear=date('Y');
-	}
-else {
-	$mmm = str_split($m, 2);
-	$nowm=zeroise(intval(substr($m, 4, 2)), 2);
-	$nowyear=$mmm['0'].$mmm['1'];
-	}
+		<div id="ajax_ac_widget">
+			<div class="select_ca">
+				<select name="month" id="my_month" >
+					<?php
+					$month = array();
+					for ($i = 1; $i <= 12; $i++) {
+						$monthnum = zeroise($i, 2);
+						$month[$monthnum] = $wp_locale->get_month($i);
+					}
 
-	
-foreach($month as $k=>$mu){
-	if($k==$nowm){
-	echo '<option value="'.$k.'" selected="selected" >'.$mu.'</option>';
-	}
-	else{
-	echo '<option value="'.$k.'">'.$mu.'</option>';	
-		}
-	}	
-	
-	?>
-     </select>
-  
-  <?php 
- $find = array("1","2","3","4","5","6","7","8","9","0",);
-$replace = array("১","২","৩","৪","৫","৬","৭","৮","৯","০",);
+					global $m;
+					if (empty($m) || $m == '') {
+						$nowm = date('m');
+						$nowyear = date('Y');
+					} else {
+						$mmm = str_split($m, 2);
+						$nowm = zeroise(intval(substr($m, 4, 2)), 2);
+						$nowyear = $mmm['0'] . $mmm['1'];
+					}
 
 
-  $taryear=$nowyear+5;
-  $yeararr=array();
-  $lassyear=$nowyear-5;
-  for($nowyearrr=$lassyear;$nowyearrr<=$taryear;$nowyearrr++){
-	  $yeararr[$nowyearrr]=$nowyearrr;	  	  
-  }
-     ?> 
-   
-      <select name="Year" id="my_year" >
-   <?php  foreach($yeararr as $k=>$year){
-	if ('bn' === substr(get_locale(), 0, 2)) {
-	   $year=str_replace($find,$replace,$year);
-	   }
-	   if($k==$nowyear){
-	echo '<option value="'.$k.'" selected="selected" >'.$year.'</option>';
-	}
-	else{
-	echo '<option value="'.$k.'">'.$year.'</option>';	
-		}
-		
-	   } ?>
+					foreach ($month as $k => $mu) {
+						if ($k == $nowm) {
+							echo '<option value="' . $k . '" selected="selected" >' . $mu . '</option>';
+						} else {
+							echo '<option value="' . $k . '">' . $mu . '</option>';
+						}
+					}
+					?>
+				</select>
 
-     </select>
-     </div><!--select ca -->
-     <div class="clear" style="clear:both; margin-bottom: 5px;"></div>
-        <div id="my_calender">
-      
-        </div><!--my_calender -->
-        <div class="aj-loging"><img src="<?php $url = plugin_dir_url(__FILE__); echo $url.'loading.gif'; ?>" /></div>
-<script type="text/javascript" >
-jQuery('#my_month').change(function(e) {
-	jQuery(".aj-loging").css("display","block");
-	jQuery("#my_calender").css("opacity","0.30");
-    var mon=jQuery(this).val();
-	var year=jQuery('#my_year').val();
-	var to=year+mon;
-	var data = {
-		action: 'ajax_ac',
-		ma: to,
-		
-	};
-
-	// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
-	jQuery.get(ajaxurl, data, function(response) {
-		jQuery("#my_calender").html(response);
-			jQuery(".aj-loging").css("display","none");
-	jQuery("#my_calender").css("opacity","1.00");
-	});
-	
-});
-jQuery(document).ready(function(e) {
-    
-});
-</script>
-<script type="text/javascript" >
-jQuery('#my_year').change(function(e) {
-	jQuery(".aj-loging").css("display","block");
-	jQuery("#my_calender").css("opacity","0.30");
-    var mon=jQuery('#my_month').val();
-	var year=jQuery('#my_year').val();
-	var to=year+mon;
-	var data = {
-		action: 'ajax_ac',
-		ma: to,
-		
-		
-	};
-
-	// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
-	jQuery.get(ajaxurl, data, function(response) {
-		jQuery("#my_calender").html(response);
-			jQuery(".aj-loging").css("display","none");
-	jQuery("#my_calender").css("opacity","1.00");
-	});
-	
-});
-jQuery(document).ready(function(e) {
-    
-});
-</script>
-
-<script type="text/javascript" >
+					<?php
+					$find = array("1", "2", "3", "4", "5", "6", "7", "8", "9", "0",);
+					$replace = array("১", "২", "৩", "৪", "৫", "৬", "৭", "৮", "৯", "০",);
 
 
-jQuery(document).ready(function(e) {
-	<?php if(!isset($_GET['m'])){ echo 'var a='.date('Ym');} else echo 'var a='.$_GET['m'];  ?>
-	
- 	var data = {
-		action: 'ajax_ac',
-		ma:a,
-		
-	};
+					$taryear = $nowyear + 5;
+					$yeararr = array();
+					$lassyear = $nowyear - 5;
+					for ($nowyearrr = $lassyear; $nowyearrr <= $taryear; $nowyearrr++) {
+						$yeararr[$nowyearrr] = $nowyearrr;
+					}
+					?> 
 
-	// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
-	jQuery.get(ajaxurl, data, function(response) {
-		
+				<select name="Year" id="my_year" >
+				<?php
+				foreach ($yeararr as $k => $year) {
+					if ('bn' === substr(get_locale(), 0, 2)) {
+						$year = str_replace($find, $replace, $year);
+					}
+					if ($k == $nowyear) {
+						echo '<option value="' . $k . '" selected="selected" >' . $year . '</option>';
+					} else {
+						echo '<option value="' . $k . '">' . $year . '</option>';
+					}
+				}
+				?>
 
-			
-		jQuery("#my_calender").html(response);
-	jQuery(".aj-loging").css("display","none");
-	jQuery("#my_calender").css("opacity","1.00");
+				</select>
+			</div><!--select ca -->
+			<div class="clear" style="clear:both; margin-bottom: 5px;"></div>
+			<div id="my_calender">
 
-	});   
-});
-</script>
-     
-        
-       </div>
+			</div><!--my_calender -->
+			<div class="aj-loging"><img src="<?php $url = plugin_dir_url(__FILE__);
+			echo $url . 'loading.gif'; ?>" /></div>
+			<script type="text/javascript" >
+				jQuery('#my_month').change(function (e) {
+					jQuery(".aj-loging").css("display", "block");
+					jQuery("#my_calender").css("opacity", "0.30");
+					var mon = jQuery(this).val();
+					var year = jQuery('#my_year').val();
+					var to = year + mon;
+					var data = {
+						action: 'ajax_ac',
+						ma: to,
 
-<?php
-		
-	
+					};
+
+					// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
+					jQuery.get(ajaxurl, data, function (response) {
+						jQuery("#my_calender").html(response);
+						jQuery(".aj-loging").css("display", "none");
+						jQuery("#my_calender").css("opacity", "1.00");
+					});
+
+				});
+				jQuery(document).ready(function (e) {
+
+				});
+			</script>
+			<script type="text/javascript" >
+				jQuery('#my_year').change(function (e) {
+					jQuery(".aj-loging").css("display", "block");
+					jQuery("#my_calender").css("opacity", "0.30");
+					var mon = jQuery('#my_month').val();
+					var year = jQuery('#my_year').val();
+					var to = year + mon;
+					var data = {
+						action: 'ajax_ac',
+						ma: to,
+
+					};
+
+					// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
+					jQuery.get(ajaxurl, data, function (response) {
+						jQuery("#my_calender").html(response);
+						jQuery(".aj-loging").css("display", "none");
+						jQuery("#my_calender").css("opacity", "1.00");
+					});
+
+				});
+				jQuery(document).ready(function (e) {
+
+				});
+			</script>
+
+			<script type="text/javascript" >
+
+
+				jQuery(document).ready(function (e) {
+		<?php if (!isset($_GET['m'])) {
+			echo 'var a=' . date('Ym');
+		} else echo 'var a=' . $_GET['m']; ?>
+
+					var data = {
+						action: 'ajax_ac',
+						ma: a,
+
+					};
+
+					// since 2.8 ajaxurl is always defined in the admin header and points to admin-ajax.php
+					jQuery.get(ajaxurl, data, function (response) {
+
+
+
+						jQuery("#my_calender").html(response);
+						jQuery(".aj-loging").css("display", "none");
+						jQuery("#my_calender").css("opacity", "1.00");
+
+					});
+				});
+			</script>
+
+
+		</div>
+
+		<?php
 		/* now end your degine
-		
-		/*arter_widget define by thimed*/
+
+		  /*arter_widget define by thimed */
 		echo $after_widget;
 	}
-	
-/******************** It Update widget *******************************/
-function update( $new_instance, $old_instance ) {
+
+	/*	 * ****************** It Update widget ****************************** */
+
+	function update($new_instance, $old_instance) {
 		$instance = $old_instance;
-		$instance['title'] = strip_tags( $new_instance['title'] );
+		$instance['title'] = strip_tags($new_instance['title']);
 		return $instance;
 	}
-/************************ It is sow only admin menu**********************************/
-	
-	function form( $instance ) {
-		$defaults = array( 'title' => 'Archive Calendar');
-		$instance = wp_parse_args( (array) $instance, $defaults );
+
+	/*	 * ********************** It is sow only admin menu********************************* */
+
+	function form($instance) {
+		$defaults = array('title' => 'Archive Calendar');
+		$instance = wp_parse_args((array) $instance, $defaults);
 		?>
-   <p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e('Title:', 'Recent post'); ?></label>
-			<input id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" value="<?php echo $instance['title']; ?>" style="width:100%;" />
-            
+		<p>
+			<label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title:', 'Recent post'); ?></label>
+			<input id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" value="<?php echo $instance['title']; ?>" style="width:100%;" />
+
 		</p>
-        
-         		
+
+
 		<?php
-	}// end from function
-}// end widget class
+	}
+
+// end from function
+}
+
+// end widget class
 
 
-add_action( 'wp_ajax_ajax_ac', 'ajax_ac_callback' );
-add_action( 'wp_ajax_nopriv_ajax_ac', 'ajax_ac_callback' );
+add_action('wp_ajax_ajax_ac', 'ajax_ac_callback');
+add_action('wp_ajax_nopriv_ajax_ac', 'ajax_ac_callback');
 
 function ajax_ac_callback() {
-$ma=$_GET['ma'];
-ajax_ac_calendar($ma);
+	$ma = $_GET['ma'];
+	ajax_ac_calendar($ma);
 	die(); // this is required to return a proper result
 }
 
-
 function ajax_ac_calendar($ma, $echo = true) {
 	global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
-	$m=& $ma;
+	$m = & $ma;
 	$cache = array();
-	$key = md5( get_locale() . $m . $monthnum . $year );
-	
-	if ( $cache = wp_cache_get( 'get_calendar', 'calendar' ) ) {
-		if ( is_array($cache) && isset( $cache[ $key ] ) ) {
-			if ( $echo ) {
-				echo apply_filters( 'get_calendar',  $cache[$key] );
+	$key = md5(get_locale() . $m . $monthnum . $year);
+
+	if ($cache = wp_cache_get('get_calendar', 'calendar')) {
+		if (is_array($cache) && isset($cache[$key])) {
+			if ($echo) {
+				echo apply_filters('get_calendar', $cache[$key]);
 				return;
 			} else {
-				return apply_filters( 'get_calendar',  $cache[$key] );
+				return apply_filters('get_calendar', $cache[$key]);
 			}
 		}
 	}
 
-	if ( !is_array($cache) )
+	if (!is_array($cache))
 		$cache = array();
 
 	// Quick check. If we have no posts at all, abort!
-	if ( !$posts ) {
+	if (!$posts) {
 		$gotsome = $wpdb->get_var("SELECT 1 as test FROM $wpdb->posts WHERE post_type = 'post' AND post_status = 'publish' LIMIT 1");
-		if ( !$gotsome ) {
-			$cache[ $key ] = '';
-			wp_cache_set( 'get_calendar', $cache, 'calendar' );
+		if (!$gotsome) {
+			$cache[$key] = '';
+			wp_cache_set('get_calendar', $cache, 'calendar');
 			return;
 		}
 	}
 
-	if ( isset($_GET['w']) )
-		$w = ''.intval($_GET['w']);
+	if (isset($_GET['w']))
+		$w = '' . intval($_GET['w']);
 
 	// week_begins = 0 stands for Sunday
 	$week_begins = intval(get_option('start_of_week'));
 
 	// Let's figure out when we are
-	if ( !empty($monthnum) && !empty($year) ) {
-		$thismonth = ''.zeroise(intval($monthnum), 2);
-		$thisyear = ''.intval($year);
-	} elseif ( !empty($w) ) {
+	if (!empty($monthnum) && !empty($year)) {
+		$thismonth = '' . zeroise(intval($monthnum), 2);
+		$thisyear = '' . intval($year);
+	} elseif (!empty($w)) {
 		// We need to get the month from MySQL
-		$thisyear = ''.intval(substr($m, 0, 4));
+		$thisyear = '' . intval(substr($m, 0, 4));
 		$d = (($w - 1) * 7) + 6; //it seems MySQL's weeks disagree with PHP's
 		$thismonth = $wpdb->get_var("SELECT DATE_FORMAT((DATE_ADD('{$thisyear}0101', INTERVAL $d DAY) ), '%m')");
-	} elseif ( !empty($m) ) {
-		$thisyear = ''.intval(substr($m, 0, 4));
-		if ( strlen($m) < 6 )
-				$thismonth = '01';
+	} elseif (!empty($m)) {
+		$thisyear = '' . intval(substr($m, 0, 4));
+		if (strlen($m) < 6)
+			$thismonth = '01';
 		else
-				$thismonth = ''.zeroise(intval(substr($m, 4, 2)), 2);
+			$thismonth = '' . zeroise(intval(substr($m, 4, 2)), 2);
 	} else {
 		$thisyear = gmdate('Y', current_time('timestamp'));
 		$thismonth = gmdate('m', current_time('timestamp'));
 	}
 
-	$unixmonth = mktime(0, 0 , 0, $thismonth, 1, $thisyear);
+	$unixmonth = mktime(0, 0, 0, $thismonth, 1, $thisyear);
 	$last_day = date('t', $unixmonth);
 
 	$calendar_output = '<table id="my-calendar">
@@ -324,17 +325,16 @@ function ajax_ac_calendar($ma, $echo = true) {
 
 	$myweek = array();
 
-	for ( $wdcount=0; $wdcount<=6; $wdcount++ ) {
-		$myweek[] = $wp_locale->get_weekday(($wdcount+$week_begins)%7);
+	for ($wdcount = 0; $wdcount <= 6; $wdcount++) {
+		$myweek[] = $wp_locale->get_weekday(($wdcount + $week_begins) % 7);
 	}
 
-	$barr=array('Saturday'=>'শনি','Sunday'=>'রবি','Monday'=>'সোম','Tuesday'=>'মঙ্গল','Wednesday'=>'বুধ','Thursday'=>'বৃহ','Friday'=>'শুক্র');
-	foreach ( $myweek as $wd ) {
+	$barr = array('Saturday' => 'শনি', 'Sunday' => 'রবি', 'Monday' => 'সোম', 'Tuesday' => 'মঙ্গল', 'Wednesday' => 'বুধ', 'Thursday' => 'বৃহ', 'Friday' => 'শুক্র');
+	foreach ($myweek as $wd) {
 		if ('bn' === substr(get_locale(), 0, 2)) {
-			$day_name=$barr[$wd];
-			}
-		else{
-		$day_name = $wp_locale->get_weekday_abbrev($wd);
+			$day_name = $barr[$wd];
+		} else {
+			$day_name = $wp_locale->get_weekday_abbrev($wd);
 		}
 		$wd = esc_attr($wd);
 		$calendar_output .= "\n\t\t<th class=\"$day_name\" scope=\"col\" title=\"$wd\">$day_name</th>";
@@ -379,186 +379,182 @@ function ajax_ac_calendar($ma, $echo = true) {
 	}
 
 	// See how much we should pad in the beginning
-	$pad = calendar_week_mod(date('w', $unixmonth)-$week_begins);
-	if ( 0 != $pad )
-		$calendar_output .= "\n\t\t".'<td colspan="'. esc_attr($pad) .'" class="pad">&nbsp;</td>';
+	$pad = calendar_week_mod(date('w', $unixmonth) - $week_begins);
+	if (0 != $pad)
+		$calendar_output .= "\n\t\t" . '<td colspan="' . esc_attr($pad) . '" class="pad">&nbsp;</td>';
 
 	$daysinmonth = intval(date('t', $unixmonth));
-	for ( $day = 1; $day <= $daysinmonth; ++$day ) {
-if ('bn' === substr(get_locale(), 0, 2)) {
-$dayrrr=array(
-'1'=>'১',
-'2'=>'২',
-'3'=>'৩',
-'4'=>'৪',
-'5'=>'৫',
-'6'=>'৬',
-'7'=>'৭',
-'8'=>'৮',
-'9'=>'৯',
-'10'=>'১০',
-'11'=>'১১',
-'12'=>'১২',
-'13'=>'১৩',
-'14'=>'১৪',
-'15'=>'১৫',
-'16'=>'১৬',
-'17'=>'১৭',
-'18'=>'১৮',
-'19'=>'১৯',
-'20'=>'২০',
-'21'=>'২১',
-'22'=>'২২',
-'23'=>'২৩',
-'24'=>'২৪',
-'25'=>'২৫',
-'26'=>'২৬',
-'27'=>'২৭',
-'28'=>'২৮',
-'29'=>'২৯',
-'30'=>'৩০',
-'31'=>'৩১',
-);
-}
-else {
-$dayrrr=array(
-'1'=>'1',
-'2'=>'2',
-'3'=>'3',
-'4'=>'4',
-'5'=>'5',
-'6'=>'6',
-'7'=>'7',
-'8'=>'8',
-'9'=>'9',
-'10'=>'10',
-'11'=>'11',
-'12'=>'12',
-'13'=>'13',
-'14'=>'14',
-'15'=>'15',
-'16'=>'16',
-'17'=>'17',
-'18'=>'18',
-'19'=>'19',
-'20'=>'20',
-'21'=>'21',
-'22'=>'22',
-'23'=>'23',
-'24'=>'24',
-'25'=>'25',
-'26'=>'26',
-'27'=>'27',
-'28'=>'28',
-'29'=>'29',
-'30'=>'30',
-'31'=>'31',
-);	
-	}
-		if ( isset($newrow) && $newrow )
+	for ($day = 1; $day <= $daysinmonth; ++$day) {
+		if ('bn' === substr(get_locale(), 0, 2)) {
+			$dayrrr = array(
+				'1' => '১',
+				'2' => '২',
+				'3' => '৩',
+				'4' => '৪',
+				'5' => '৫',
+				'6' => '৬',
+				'7' => '৭',
+				'8' => '৮',
+				'9' => '৯',
+				'10' => '১০',
+				'11' => '১১',
+				'12' => '১২',
+				'13' => '১৩',
+				'14' => '১৪',
+				'15' => '১৫',
+				'16' => '১৬',
+				'17' => '১৭',
+				'18' => '১৮',
+				'19' => '১৯',
+				'20' => '২০',
+				'21' => '২১',
+				'22' => '২২',
+				'23' => '২৩',
+				'24' => '২৪',
+				'25' => '২৫',
+				'26' => '২৬',
+				'27' => '২৭',
+				'28' => '২৮',
+				'29' => '২৯',
+				'30' => '৩০',
+				'31' => '৩১',
+			);
+		} else {
+			$dayrrr = array(
+				'1' => '1',
+				'2' => '2',
+				'3' => '3',
+				'4' => '4',
+				'5' => '5',
+				'6' => '6',
+				'7' => '7',
+				'8' => '8',
+				'9' => '9',
+				'10' => '10',
+				'11' => '11',
+				'12' => '12',
+				'13' => '13',
+				'14' => '14',
+				'15' => '15',
+				'16' => '16',
+				'17' => '17',
+				'18' => '18',
+				'19' => '19',
+				'20' => '20',
+				'21' => '21',
+				'22' => '22',
+				'23' => '23',
+				'24' => '24',
+				'25' => '25',
+				'26' => '26',
+				'27' => '27',
+				'28' => '28',
+				'29' => '29',
+				'30' => '30',
+				'31' => '31',
+			);
+		}
+		if (isset($newrow) && $newrow)
 			$calendar_output .= "\n\t</tr>\n\t<tr>\n\t\t";
 		$newrow = false;
 
 
 
-		if ( $day == gmdate('j', current_time('timestamp')) && $thismonth == gmdate('m', current_time('timestamp')) && $thisyear == gmdate('Y', current_time('timestamp')) )
-		
+		if ($day == gmdate('j', current_time('timestamp')) && $thismonth == gmdate('m', current_time('timestamp')) && $thisyear == gmdate('Y', current_time('timestamp')))
 			$calendar_output .= '<td id="today"  >';
 		else
 			$calendar_output .= '<td class="notday">';
 
-		if ( in_array($day, $daywithpost) ) // any posts today?
-				$calendar_output .= '<a class="has-post" href="' . get_day_link( $thisyear, $thismonth, $day ) . '" title="' . esc_attr( $ak_titles_for_day[ $day ] ) . "\">$dayrrr[$day]</a>";
+		if (in_array($day, $daywithpost)) // any posts today?
+			$calendar_output .= '<a class="has-post" href="' . get_day_link($thisyear, $thismonth, $day) . '" title="' . esc_attr($ak_titles_for_day[$day]) . "\">$dayrrr[$day]</a>";
 		else
-			$calendar_output .='<span class="notpost">'.$dayrrr[$day].'</span>';
+			$calendar_output .= '<span class="notpost">' . $dayrrr[$day] . '</span>';
 		$calendar_output .= '</td>';
 
-		if ( 6 == calendar_week_mod(date('w', mktime(0, 0 , 0, $thismonth, $day, $thisyear))-$week_begins) )
+		if (6 == calendar_week_mod(date('w', mktime(0, 0, 0, $thismonth, $day, $thisyear)) - $week_begins))
 			$newrow = true;
 	}
 
-	$pad = 7 - calendar_week_mod(date('w', mktime(0, 0 , 0, $thismonth, $day, $thisyear))-$week_begins);
-	if ( $pad != 0 && $pad != 7 )
-		$calendar_output .= "\n\t\t".'<td class="pad" colspan="'. esc_attr($pad) .'">&nbsp;</td>';
+	$pad = 7 - calendar_week_mod(date('w', mktime(0, 0, 0, $thismonth, $day, $thisyear)) - $week_begins);
+	if ($pad != 0 && $pad != 7)
+		$calendar_output .= "\n\t\t" . '<td class="pad" colspan="' . esc_attr($pad) . '">&nbsp;</td>';
 
 	$calendar_output .= "\n\t</tr>\n\t</tbody>\n\t</table>";
 
-	$cache[ $key ] = $calendar_output;
-	wp_cache_set( 'get_calendar', $cache, 'calendar' );
+	$cache[$key] = $calendar_output;
+	wp_cache_set('get_calendar', $cache, 'calendar');
 
-	if ( $echo )
-		echo apply_filters( 'get_calendar',  $calendar_output );
+	if ($echo)
+		echo apply_filters('get_calendar', $calendar_output);
 	else
-		return apply_filters( 'get_calendar',  $calendar_output );
-
+		return apply_filters('get_calendar', $calendar_output);
 }
 
-function ajax_ac_head(){?>
-<script type="text/javascript">
-var ajaxurl = '<?php echo admin_url('admin-ajax.php'); ?>';
-</script>
+function ajax_ac_head() {
+	?>
+	<script type="text/javascript">
+	    var ajaxurl = '<?php echo admin_url('admin-ajax.php'); ?>';
+	</script>
 
-<style type="text/css">
+	<style type="text/css">
 
-#ajax_ac_widget th {
-    background: none repeat scroll 0 0 #008000;
-    color: #FFFFFF;
-    font-weight: normal;
-    padding: 5px 1px;
-    text-align: center;
-	 font-size: 16px;
-}
-#ajax_ac_widget {
-    padding: 5px;
+		#ajax_ac_widget th {
+			background: none repeat scroll 0 0 #008000;
+			color: #FFFFFF;
+			font-weight: normal;
+			padding: 5px 1px;
+			text-align: center;
+			font-size: 16px;
+		}
+		#ajax_ac_widget {
+			padding: 5px;
+		}
+
+		#ajax_ac_widget td {
+			border: 1px solid #CCCCCC;
+			text-align: center;
+		}
+
+		#my-calendar a {
+			background: none repeat scroll 0 0 #008000;
+			color: #FFFFFF;
+			display: block;
+			padding: 6px 0;
+			width: 100% !important;
+			border-radius:20px;
+		}
+		#my-calendar{
+			width:100%;
+		}
+
+
+		#my_calender span {
+			display: block;
+			padding: 6px 0;
+			width: 100% !important;
+			background-color:#999;
+			border-radius:20px;
+		}
+
+		#today a,#today span {
+			background: none repeat scroll 0 0 #FF0000 !important;
+			color: #FFFFFF;
+			border-radius:20px;
+		}
+		#ajax_ac_widget #my_year {
+			float: right;
+		}
+		.select_ca #my_month {
+			float: left;
+		}
+		.aj-loging > img {
+			margin-left: 140px;
+			margin-top: -100px;
+			position: absolute;
+		}
+
+	</style>
+	<?php
 }
 
-#ajax_ac_widget td {
-    border: 1px solid #CCCCCC;
-    text-align: center;
-}
-
-#my-calendar a {
-    background: none repeat scroll 0 0 #008000;
-    color: #FFFFFF;
-    display: block;
-    padding: 6px 0;
-    width: 100% !important;
-	border-radius:20px;
-}
-#my-calendar{
-	width:100%;
-}
-
-
-#my_calender span {
-    display: block;
-    padding: 6px 0;
-    width: 100% !important;
-	background-color:#999;
-	border-radius:20px;
-}
-
-#today a,#today span {
-       background: none repeat scroll 0 0 #FF0000 !important;
-    color: #FFFFFF;
-	border-radius:20px;
-}
-#ajax_ac_widget #my_year {
-    float: right;
-}
-.select_ca #my_month {
-    float: left;
-}
-.aj-loging > img {
-    margin-left: 140px;
-    margin-top: -100px;
-    position: absolute;
-}
-
-</style>
-<?php	
-	}
-	add_filter('wp_head', 'ajax_ac_head');
-	
-
-?>
+add_filter('wp_head', 'ajax_ac_head');


### PR DESCRIPTION
Use WordPress functions to get posts so that WPML can filter the results by language.
Get the list of months from WP (it was hardcoded).
Remove warning messages.
Reformat source code.
