### PR TITLE
PHP Notice:  Use of undefined constant m - assumed 'm'

### DIFF
--- a/ajax-archive-calendar.php
+++ b/ajax-archive-calendar.php
@@ -98,10 +98,10 @@ class ajax_ac_widget extends WP_Widget {
 						$nowm = $monthnum;
 						$nowyear = $year;
 						if($monthnum==0 || $monthnum==null){
-							$nowm=date(m);
+							$nowm=date('m');
 						}
 						if($nowyear==0 || $nowyear==null){
-							$nowyear=date(Y);
+							$nowyear=date('Y');
 						}
 					} else {
 						$mmm = str_split($m, 2);


### PR DESCRIPTION
Corrected a PHP notice: using constant instead of a value. :)